### PR TITLE
rill saves and loads connection capacity

### DIFF
--- a/rill/engine/network.py
+++ b/rill/engine/network.py
@@ -627,7 +627,7 @@ class Graph(object):
                         if outport.component.hidden:
                             continue
                         definition['connections'].append(
-                            fbp_edge(outport, inport, self.name, 'process'))
+                            fbp_edge(outport, inport, self.name, self.default_capacity, 'process'))
 
         for (name, inport) in self.inports.items():
             definition['inports'][name] = {
@@ -691,7 +691,10 @@ class Graph(object):
             else:
                 # connection
                 src = _port(connection['src'], 'out')
-                graph.connect(src, tgt)
+                if 'cap' in connection.keys():
+                    graph.connect(src, tgt, connection_capacity=connection['cap'])
+                else:
+                    graph.connect(src, tgt)
 
         for (name, inport) in definition['inports'].items():
             graph.export(_port(inport, 'in'), name)

--- a/rill/events/listeners/memory.py
+++ b/rill/events/listeners/memory.py
@@ -39,12 +39,15 @@ def fbp_port(port, node_label='node'):
     return doc
 
 
-def fbp_edge(outport, inport, graph_id, node_label='node'):
+def fbp_edge(outport, inport, graph_id, default_capacity, node_label='node'):
     connection = {
         'src': fbp_port(outport, node_label),
         'tgt': fbp_port(inport, node_label)
     }
     conn = inport._connection
+    cap = conn.capacity()
+    if cap !=default_capacity:
+        connection.update({'cap':conn.capacity()})
     # keyed on outport
     metadata = conn.metadata.get(outport, None)
     if metadata:


### PR DESCRIPTION
rill.engine.network.Graph().to_dict() output:

{'src': inport
'tgt': outport}

is now 

{'src': inport
'tgt': outport
'cap': connection capacity}

when the connection is set to a non-default capacity